### PR TITLE
Math error, take square root, not square, for magnitude of a vector

### DIFF
--- a/TB_CustomControlsSwift/BWCircularSlider.swift
+++ b/TB_CustomControlsSwift/BWCircularSlider.swift
@@ -249,7 +249,7 @@ class BWCircularSlider: UIControl {
     //Calculate the direction in degrees from a center point to an arbitrary position.
     func AngleFromNorth(p1:CGPoint , p2:CGPoint , flipped:Bool) -> Double {
         var v:CGPoint  = CGPointMake(p2.x - p1.x, p2.y - p1.y)
-        let vmag:CGFloat = Square(Square(v.x) + Square(v.y))
+        let vmag:CGFloat = sqrt(Square(v.x) + Square(v.y))
         var result:Double = 0.0
         v.x /= vmag;
         v.y /= vmag;


### PR DESCRIPTION
When taking the vector magnitude the formula should be taking the square root here, not squaring the result.
From this Square(x^2 + y^2) to this sqrt(x^2 + y^2).